### PR TITLE
Use RbConfig instead of Config.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -56,9 +56,9 @@ File.open("conftest.c", "w") do |f|
   f.puts src
 end
 if defined? cpp_command then
-  cpp = Config.expand(cpp_command(''))
+  cpp = RbConfig.expand(cpp_command(''))
 else
-  cpp = Config.expand sprintf(CPP, $CPPFLAGS, $CFLAGS, '')
+  cpp = RbConfig.expand sprintf(CPP, $CPPFLAGS, $CFLAGS, '')
 end
 if /mswin32/ =~ RUBY_PLATFORM && !/-E/.match(cpp)
   cpp << " -E"

--- a/mysqlplus.gemspec
+++ b/mysqlplus.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name     = "mysqlplus"
-  s.version  = "0.1.1"
-  s.date     = "2009-03-22"
+  s.version  = "0.1.3"
+  s.date     = "2014-12-29"
   s.summary  = "Enhanced Ruby MySQL driver"
   s.email    = "oldmoe@gmail.com"
   s.homepage = "http://github.com/oldmoe/mysqlplus"


### PR DESCRIPTION
As of Ruby 2.2.0, Config no longer exists. Attempting to install the mysqlplus gem produces the following error:

```
extconf.rb:59:in `<main>': uninitialized constant Config (NameError)

extconf failed, exit code 1
```

This commit makes extconf.rb use RbConfig instead of Config.
