### PR TITLE
Guard two more calls to rb_thread_blocking_region.

### DIFF
--- a/ext/mysql.c
+++ b/ext/mysql.c
@@ -907,7 +907,7 @@ static VALUE query(VALUE obj, VALUE sql)
         rb_raise(eMysql, "query: not connected");
     }
     if (rb_block_given_p()) {
-        #ifdef RUBY_VM
+        #if defined RUBY_VM && defined HAVE_TBR
 	    args.m = m;
 	    args.data = RSTRING_PTR(sql);
 	    args.len = RSTRING_LEN(sql);
@@ -937,7 +937,7 @@ static VALUE query(VALUE obj, VALUE sql)
 	return obj;
     }
     
-    #ifdef RUBY_VM
+    #if defined RUBY_VM && defined HAVE_TBR
 	args.m = m;
 	args.data = RSTRING_PTR(sql);
 	args.len = RSTRING_LEN(sql);


### PR DESCRIPTION
This is another problem I ran into with mysqlplus under Ruby 2.2.0. This version of Ruby no longer has rb_thread_blocking_region(), so when I actually tried to use mysqlplus, I got this error:

    dyld: lazy symbol binding failed: Symbol not found: _rb_thread_blocking_region
      Referenced from: /Users/mortonfox/.rvm/gems/ruby-2.2.0/gems/mysqlplus-0.1.3/lib/mysql.bundle
      Expected in: flat namespace

I checked ext/mysql.c and found two calls to rb_thread_blocking_region() that weren't guarded by HAVE_TBR, so I added those guards.
